### PR TITLE
Adds oclc field in record page #139

### DIFF
--- a/module/CRL/src/CRL/View/Helper/CRL/RecordDataFormatterFactory.php
+++ b/module/CRL/src/CRL/View/Helper/CRL/RecordDataFormatterFactory.php
@@ -32,6 +32,13 @@
             null,
             ['recordLink' => 'title']
         );
+        $spec->setLine(
+            'OCLC',
+            'getOCLC',
+            null,
+            ['itemPrefix' => '<span property="oclc">',
+             'itemSuffix' => '</span>']
+        );
         $spec->setMultiLine(
             'Authors',
             'getDeduplicatedAuthors',


### PR DESCRIPTION
## Description

See #139 

Adds OCLC number above author field in record page like in the old catalog

## Screenshot
![Screen Shot 2022-06-30 at 4 56 31 PM](https://user-images.githubusercontent.com/11491604/176785667-7473bbc8-5484-4fdd-962e-5a0f25ab0834.png)


closes #139 